### PR TITLE
Control if redis uses async-std or tokio via feature flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,24 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       # https://twitter.com/jonhoo/status/1571290371124260865
-      - name: cargo test --locked
+      - name: cargo test --locked --all-features --all-targets
         run: cargo test --locked --all-features --all-targets
+  # Not all tests run with the --all-features flag. 
+  # This job is to ensure that tests that pertain only to the default feature set are run.
+  default-features:
+    runs-on: ubuntu-latest
+    name: ubuntu / stable / default-features 
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install stable 
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+      - name: cargo test --locked
+        run: cargo test --locked --all-targets
   minimal:
     runs-on: ubuntu-latest
     name: ubuntu / stable / minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,13 @@ license = "BSD-3-Clause"
 readme = "README.md"
 edition = "2021"
 
+[features]
+async-std-comp = ["redis/async-std-comp"]
+tokio-comp = ["redis/tokio-comp"]
+default = ["async-std-comp"]
+
 [dependencies]
-redis = { version = "0.21.6", features = ["async-std-comp"] }
+redis = { version = "0.21.6" }
 tokio = { version = "1.27.0", features = ["rt", "time"] }
 rand = "0.8.5"
 futures = "0.3.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
 mod lock;
 
+#[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
 pub use crate::lock::{Lock, LockError, LockGuard, LockManager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
 mod lock;
 
-#[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
-pub use crate::lock::{Lock, LockError, LockManager};
-#[cfg(all(feature = "async-std-comp", not(feature = "tokio-comp")))]
-pub use crate::lock::LockGuard;
+pub use crate::lock::{Lock, LockError, LockManager, LockGuard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
 mod lock;
 
-pub use crate::lock::{Lock, LockError, LockGuard, LockManager};
+#[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
+pub use crate::lock::{Lock, LockError, LockManager};
+#[cfg(all(feature = "async-std-comp", not(feature = "tokio-comp")))]
+pub use crate::lock::LockGuard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 mod lock;
 
-pub use crate::lock::{Lock, LockError, LockManager, LockGuard};
+pub use crate::lock::{Lock, LockError, LockGuard, LockManager};

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -328,6 +328,7 @@ mod tests {
         is_normal::<LockManager>();
         is_normal::<LockError>();
         is_normal::<Lock>();
+        #[cfg(not(feature = "tokio-comp"))]
         is_normal::<LockGuard>();
     }
 
@@ -492,6 +493,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(feature = "tokio-comp"))]
     #[tokio::test]
     async fn test_lock_lock_unlock_raii() -> Result<()> {
         let (_containers, addresses) = create_clients();
@@ -523,6 +525,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(feature = "tokio-comp"))]
     #[tokio::test]
     async fn test_lock_extend_lock() -> Result<()> {
         let (_containers, addresses) = create_clients();
@@ -557,6 +560,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(feature = "tokio-comp"))]
     #[tokio::test]
     async fn test_lock_extend_lock_releases() -> Result<()> {
         let (_containers, addresses) = create_clients();

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -63,23 +63,22 @@ pub struct Lock<'a> {
 }
 
 /// Upon dropping the guard, `LockManager::unlock` will be ran synchronously on the executor.
-/// 
-/// This is known to block the tokio runtime if this happens inside of the context of a tokio runtime 
+///
+/// This is known to block the tokio runtime if this happens inside of the context of a tokio runtime
 /// if `tokio-comp` is enabled as a feature on this crate or the `redis` crate.
 ///
-/// To eliminate this risk, if the `tokio-comp` flag is enabled, the `Drop` impl will not be compiled, 
+/// To eliminate this risk, if the `tokio-comp` flag is enabled, the `Drop` impl will not be compiled,
 /// meaning that dropping the `LockGuard` will be a no-op.
-/// Under this circumstance, `LockManager::unlock` can be called manually using the inner `lock` at the appropriate 
-/// point to release the lock taken in `Redis`. 
+/// Under this circumstance, `LockManager::unlock` can be called manually using the inner `lock` at the appropriate
+/// point to release the lock taken in `Redis`.
 #[derive(Debug, Clone)]
 pub struct LockGuard<'a> {
     pub lock: Lock<'a>,
 }
 
-
-/// Dropping this guard inside the context of a tokio runtime if `tokio-comp` is enabled 
-/// will block the tokio runtime. 
-/// Because of this, the guard is not compiled if `tokio-comp` is enabled. 
+/// Dropping this guard inside the context of a tokio runtime if `tokio-comp` is enabled
+/// will block the tokio runtime.
+/// Because of this, the guard is not compiled if `tokio-comp` is enabled.
 #[cfg(not(feature = "tokio-comp"))]
 impl Drop for LockGuard<'_> {
     fn drop(&mut self) {
@@ -269,16 +268,16 @@ impl LockManager {
 
     /// Loops until the lock is acquired.
     ///
-    /// The lock is placed in a guard that will unlock the lock when the guard is dropped. 
+    /// The lock is placed in a guard that will unlock the lock when the guard is dropped.
     #[cfg(feature = "async-std-comp")]
     pub async fn acquire<'a>(&'a self, resource: &'a [u8], ttl: usize) -> LockGuard<'a> {
         let lock = self.acquire_no_guard(resource, ttl).await;
-        LockGuard{lock}
+        LockGuard { lock }
     }
 
     /// Loops until the lock is acquired.
-    /// 
-    /// Either lock's value must expire after the ttl has elapsed, 
+    ///
+    /// Either lock's value must expire after the ttl has elapsed,
     /// or `LockManager::unlock` must be called to allow other clients to lock the same resource.
     pub async fn acquire_no_guard<'a>(&'a self, resource: &'a [u8], ttl: usize) -> Lock<'a> {
         loop {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -502,7 +502,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(all(not(feature = "tokio-comp"), feature="async-std-comp"))]
+    #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
     #[tokio::test]
     async fn test_lock_lock_unlock_raii() -> Result<()> {
         let (_containers, addresses) = create_clients();
@@ -533,7 +533,7 @@ mod tests {
 
         Ok(())
     }
-    
+
     #[cfg(feature = "tokio-comp")]
     #[tokio::test]
     async fn test_lock_lock_raii_does_not_unlock_with_tokio_enabled() -> Result<()> {
@@ -561,7 +561,6 @@ mod tests {
         if let Ok(_) = rl2.lock(&key, 1000).await {
             panic!("Lock couldn't be acquired");
         }
-        
 
         Ok(())
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -62,11 +62,17 @@ pub struct Lock<'a> {
     pub lock_manager: &'a LockManager,
 }
 
+#[cfg(not(feature = "tokio-comp"))]
 #[derive(Debug, Clone)]
 pub struct LockGuard<'a> {
     pub lock: Lock<'a>,
 }
 
+
+// Dropping this guard inside the context of a tokio runtime if tokio-comp is enabled 
+// will block the tokio runtime. 
+// Because of this, the guard is not compiled if tokio-comp is enabled. 
+#[cfg(not(feature = "tokio-comp"))]
 impl Drop for LockGuard<'_> {
     fn drop(&mut self) {
         futures::executor::block_on(self.lock.lock_manager.unlock(&self.lock));
@@ -253,10 +259,20 @@ impl LockManager {
         .await
     }
 
+    /// Loops until the lock is acquired.
+    ///
+    /// The lock is placed in a guard that will unlock the lock when the guard is dropped.
+    #[cfg(not(feature = "tokio-comp"))]
     pub async fn acquire<'a>(&'a self, resource: &'a [u8], ttl: usize) -> LockGuard<'a> {
+        let lock = self.acquire_no_guard(resource, ttl).await;
+        LockGuard{lock}
+    }
+
+    /// Loops until the lock is acquired.
+    pub async fn acquire_no_guard<'a>(&'a self, resource: &'a [u8], ttl: usize) -> Lock<'a> {
         loop {
             if let Ok(lock) = self.lock(resource, ttl).await {
-                return LockGuard { lock };
+                return lock;
             }
         }
     }


### PR DESCRIPTION
I saw that this project was pulling in async-std in as a dependency. My project didn't otherwise use async-std, instead using tokio, and would prefer to avoid async-std if possible. 

So to preserve the current behavior, I pulled out `async-std-comp` into its own feature flag and made it the default. I then tested this against my project that was already using rslock, setting `default-features = false` and `features = ["tokio-comp"]` and found that it was functionally the same, and saved me from compiling ~15 dependencies I evidently didn't need.

Since you directly depend on tokio anyways, I'm curious if the default shouldn't be `tokio-comp` instead of `async-std-comp` to avoid pulling in both, since downstream projects likely only include one or the other. Thoughts?