### PR TITLE
Relax lifetime obligation on lock, and acquire

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -195,7 +195,7 @@ impl LockManager {
         value: &[u8],
         ttl: usize,
         lock: T,
-    ) -> Result<Lock<'_>, LockError>
+    ) -> Result<Lock<'a>, LockError>
     where
         T: Fn(&'b Client) -> Fut + 'a,
         Fut: Future<Output = bool> + 'b,
@@ -257,7 +257,7 @@ impl LockManager {
     ///
     /// If it fails. `None` is returned.
     /// A user should retry after a short wait time.
-    pub async fn lock<'a>(&'a self, resource: &'a [u8], ttl: usize) -> Result<Lock<'_>, LockError> {
+    pub async fn lock<'a, 'b: 'a>(&'a self, resource: &'b [u8], ttl: usize) -> Result<Lock<'a>, LockError> {
         let val = self.get_unique_lock_id().unwrap();
 
         self.exec_or_retry(resource, &val.clone(), ttl, move |client| {
@@ -270,7 +270,7 @@ impl LockManager {
     ///
     /// The lock is placed in a guard that will unlock the lock when the guard is dropped.
     #[cfg(feature = "async-std-comp")]
-    pub async fn acquire<'a>(&'a self, resource: &'a [u8], ttl: usize) -> LockGuard<'a> {
+    pub async fn acquire<'a, 'b: 'a>(&'a self, resource: &'b [u8], ttl: usize) -> LockGuard<'a> {
         let lock = self.acquire_no_guard(resource, ttl).await;
         LockGuard { lock }
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -257,7 +257,11 @@ impl LockManager {
     ///
     /// If it fails. `None` is returned.
     /// A user should retry after a short wait time.
-    pub async fn lock<'a, 'b: 'a>(&'a self, resource: &'b [u8], ttl: usize) -> Result<Lock<'a>, LockError> {
+    pub async fn lock<'a, 'b: 'a>(
+        &'a self,
+        resource: &'b [u8],
+        ttl: usize,
+    ) -> Result<Lock<'a>, LockError> {
         let val = self.get_unique_lock_id().unwrap();
 
         self.exec_or_retry(resource, &val.clone(), ttl, move |client| {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -277,7 +277,7 @@ impl LockManager {
     ///
     /// Either lock's value must expire after the ttl has elapsed,
     /// or `LockManager::unlock` must be called to allow other clients to lock the same resource.
-    pub async fn acquire_no_guard<'a>(&'a self, resource: &'a [u8], ttl: usize) -> Lock<'a> {
+    pub async fn acquire_no_guard<'a>(&'a self, resource: &[u8], ttl: usize) -> Lock<'a> {
         loop {
             if let Ok(lock) = self.lock(resource, ttl).await {
                 return lock;
@@ -375,7 +375,7 @@ mod tests {
         let key = rl.get_unique_lock_id()?;
 
         let val = rl.get_unique_lock_id()?;
-        assert!(!rl.unlock_instance(&rl.servers[0], &key, &val).await);
+        assert!(!LockManager::unlock_instance(&rl.servers[0], &key, &val).await);
 
         Ok(())
     }
@@ -391,7 +391,7 @@ mod tests {
         let mut con = rl.servers[0].get_connection()?;
         redis::cmd("SET").arg(&*key).arg(&*val).execute(&mut con);
 
-        assert!(rl.unlock_instance(&rl.servers[0], &key, &val).await);
+        assert!(LockManager::unlock_instance(&rl.servers[0], &key, &val).await);
 
         Ok(())
     }
@@ -407,10 +407,7 @@ mod tests {
         let mut con = rl.servers[0].get_connection()?;
 
         redis::cmd("DEL").arg(&*key).execute(&mut con);
-        assert!(
-            rl.lock_instance(&rl.servers[0], &*key, val.clone(), 1000)
-                .await
-        );
+        assert!(LockManager::lock_instance(&rl.servers[0], &*key, val.clone(), 1000).await);
 
         Ok(())
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -255,11 +255,7 @@ impl LockManager {
     ///
     /// If it fails. `None` is returned.
     /// A user should retry after a short wait time.
-    pub async fn lock<'a>(
-        &'a self,
-        resource: &[u8],
-        ttl: usize,
-    ) -> Result<Lock<'a>, LockError> {
+    pub async fn lock<'a>(&'a self, resource: &[u8], ttl: usize) -> Result<Lock<'a>, LockError> {
         let val = self.get_unique_lock_id().unwrap();
 
         self.exec_or_retry(resource, &val.clone(), ttl, move |client| {
@@ -290,11 +286,7 @@ impl LockManager {
     }
 
     /// Extend the given lock by given time in milliseconds
-    pub async fn extend<'a>(
-        &'a self,
-        lock: &Lock<'a>,
-        ttl: usize,
-    ) -> Result<Lock<'a>, LockError> {
+    pub async fn extend<'a>(&'a self, lock: &Lock<'a>, ttl: usize) -> Result<Lock<'a>, LockError> {
         self.exec_or_retry(&lock.resource, &lock.val, ttl, move |client| {
             Self::extend_lock_instance(client, &lock.resource, &lock.val, ttl)
         })


### PR DESCRIPTION
The existing lifetime bounds were limiting what I could do with the `resource` argument.

The following code would not compile:
```rust
fn test() {
    let client = LockManager::new::<String>(vec![]);
    
    const PREFIX: &'static str = "prefix";
    async fn actual_test<'a>(client: &'a LockManager, resource: &str) -> LockGuard<'a> {
        let resource = format!("{}_{resource}", PREFIX);
        client.acquire(resource.as_bytes(), 10000).await
    }
}
```

with an error like:
```
        client.acquire(resource.as_bytes(), 10000).await
        ^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^
        |              |
        |              `resource` is borrowed here
        returns a value referencing data owned by the current function
```

The change in this PR allows that sample to compile by no longer forcing `resource` and `self` to live for the same lifetime. 