### PR TITLE
Wrap `LockMagager` in a `Arc` to make it `Send`

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -66,7 +66,7 @@ struct LockManagerInner {
     quorum: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Lock {
     /// The resource to lock. Will be used as the key in Redis.
     pub resource: Vec<u8>,
@@ -88,7 +88,7 @@ pub struct Lock {
 /// meaning that dropping the `LockGuard` will be a no-op.
 /// Under this circumstance, `LockManager::unlock` can be called manually using the inner `lock` at the appropriate
 /// point to release the lock taken in `Redis`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LockGuard {
     pub lock: Lock,
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::future::join_all;
@@ -53,15 +54,20 @@ pub enum LockError {
 /// and handles the Redis connections.
 #[derive(Debug, Clone)]
 pub struct LockManager {
-    /// List of all Redis clients
-    pub servers: Vec<Client>,
-    quorum: u32,
+    lock_manager_inner: Arc<LockManagerInner>,
     retry_count: u32,
     retry_delay: Duration,
 }
 
 #[derive(Debug, Clone)]
-pub struct Lock<'a> {
+struct LockManagerInner {
+    /// List of all Redis clients
+    pub servers: Vec<Client>,
+    quorum: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct Lock {
     /// The resource to lock. Will be used as the key in Redis.
     pub resource: Vec<u8>,
     /// The value for this lock.
@@ -70,7 +76,7 @@ pub struct Lock<'a> {
     /// Should only be slightly smaller than the requested TTL.
     pub validity_time: usize,
     /// Used to limit the lifetime of a lock to its lock manager.
-    pub lock_manager: &'a LockManager,
+    pub lock_manager: LockManager,
 }
 
 /// Upon dropping the guard, `LockManager::unlock` will be ran synchronously on the executor.
@@ -83,15 +89,15 @@ pub struct Lock<'a> {
 /// Under this circumstance, `LockManager::unlock` can be called manually using the inner `lock` at the appropriate
 /// point to release the lock taken in `Redis`.
 #[derive(Debug, Clone)]
-pub struct LockGuard<'a> {
-    pub lock: Lock<'a>,
+pub struct LockGuard {
+    pub lock: Lock,
 }
 
 /// Dropping this guard inside the context of a tokio runtime if `tokio-comp` is enabled
 /// will block the tokio runtime.
 /// Because of this, the guard is not compiled if `tokio-comp` is enabled.
 #[cfg(not(feature = "tokio-comp"))]
-impl Drop for LockGuard<'_> {
+impl Drop for LockGuard {
     fn drop(&mut self) {
         futures::executor::block_on(self.lock.lock_manager.unlock(&self.lock));
     }
@@ -111,8 +117,7 @@ impl LockManager {
             .collect();
 
         LockManager {
-            servers,
-            quorum,
+            lock_manager_inner: Arc::new(LockManagerInner { servers, quorum }),
             retry_count: DEFAULT_RETRY_COUNT,
             retry_delay: DEFAULT_RETRY_DELAY,
         }
@@ -204,14 +209,14 @@ impl LockManager {
         value: &[u8],
         ttl: usize,
         lock: T,
-    ) -> Result<Lock<'a>, LockError>
+    ) -> Result<Lock, LockError>
     where
         T: Fn(&'a Client) -> Fut,
         Fut: Future<Output = bool>,
     {
         for _ in 0..self.retry_count {
             let start_time = Instant::now();
-            let n = join_all(self.servers.iter().map(&lock))
+            let n = join_all(self.lock_manager_inner.servers.iter().map(&lock))
                 .await
                 .into_iter()
                 .fold(0, |count, locked| if locked { count + 1 } else { count });
@@ -228,16 +233,17 @@ impl LockManager {
                 - elapsed.as_secs() as usize * 1000
                 - elapsed.subsec_nanos() as usize / 1_000_000;
 
-            if n >= self.quorum && validity_time > 0 {
+            if n >= self.lock_manager_inner.quorum && validity_time > 0 {
                 return Ok(Lock {
-                    lock_manager: self,
+                    lock_manager: self.clone(),
                     resource: resource.to_vec(),
                     val: value.to_vec(),
                     validity_time,
                 });
             } else {
                 join_all(
-                    self.servers
+                    self.lock_manager_inner
+                        .servers
                         .iter()
                         .map(|client| Self::unlock_instance(client, resource, value)),
                 )
@@ -260,9 +266,10 @@ impl LockManager {
     ///
     /// Unlock is best effort. It will simply try to contact all instances
     /// and remove the key.
-    pub async fn unlock(&self, lock: &Lock<'_>) {
+    pub async fn unlock(&self, lock: &Lock) {
         join_all(
-            self.servers
+            self.lock_manager_inner
+                .servers
                 .iter()
                 .map(|client| Self::unlock_instance(client, &lock.resource, &lock.val)),
         )
@@ -278,7 +285,7 @@ impl LockManager {
     /// A user should retry after a short wait time.
     ///
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
-    pub async fn lock<'a>(&'a self, resource: &[u8], ttl: Duration) -> Result<Lock<'a>, LockError> {
+    pub async fn lock(&self, resource: &[u8], ttl: Duration) -> Result<Lock, LockError> {
         let val = self.get_unique_lock_id().map_err(LockError::Io)?;
         let ttl = ttl
             .as_millis()
@@ -297,11 +304,7 @@ impl LockManager {
     ///
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
     #[cfg(feature = "async-std-comp")]
-    pub async fn acquire<'a>(
-        &'a self,
-        resource: &[u8],
-        ttl: Duration,
-    ) -> Result<LockGuard<'a>, LockError> {
+    pub async fn acquire(&self, resource: &[u8], ttl: Duration) -> Result<LockGuard, LockError> {
         let lock = self.acquire_no_guard(resource, ttl).await?;
         Ok(LockGuard { lock })
     }
@@ -312,11 +315,11 @@ impl LockManager {
     /// or `LockManager::unlock` must be called to allow other clients to lock the same resource.
     ///
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
-    pub async fn acquire_no_guard<'a>(
-        &'a self,
+    pub async fn acquire_no_guard(
+        &self,
         resource: &[u8],
         ttl: Duration,
-    ) -> Result<Lock<'a>, LockError> {
+    ) -> Result<Lock, LockError> {
         loop {
             match self.lock(resource, ttl).await {
                 Ok(lock) => return Ok(lock),
@@ -327,11 +330,7 @@ impl LockManager {
     }
 
     /// Extend the given lock by given time in milliseconds
-    pub async fn extend<'a>(
-        &'a self,
-        lock: &Lock<'a>,
-        ttl: Duration,
-    ) -> Result<Lock<'a>, LockError> {
+    pub async fn extend(&self, lock: &Lock, ttl: Duration) -> Result<Lock, LockError> {
         let ttl = ttl
             .as_millis()
             .try_into()
@@ -413,8 +412,8 @@ mod tests {
 
         let rl = LockManager::new(addresses.clone());
 
-        assert_eq!(3, rl.servers.len());
-        assert_eq!(2, rl.quorum);
+        assert_eq!(3, rl.lock_manager_inner.servers.len());
+        assert_eq!(2, rl.lock_manager_inner.quorum);
     }
 
     #[tokio::test]
@@ -425,7 +424,7 @@ mod tests {
         let key = rl.get_unique_lock_id()?;
 
         let val = rl.get_unique_lock_id()?;
-        assert!(!LockManager::unlock_instance(&rl.servers[0], &key, &val).await);
+        assert!(!LockManager::unlock_instance(&rl.lock_manager_inner.servers[0], &key, &val).await);
 
         Ok(())
     }
@@ -438,10 +437,10 @@ mod tests {
         let key = rl.get_unique_lock_id()?;
 
         let val = rl.get_unique_lock_id()?;
-        let mut con = rl.servers[0].get_connection()?;
+        let mut con = rl.lock_manager_inner.servers[0].get_connection()?;
         redis::cmd("SET").arg(&*key).arg(&*val).execute(&mut con);
 
-        assert!(LockManager::unlock_instance(&rl.servers[0], &key, &val).await);
+        assert!(LockManager::unlock_instance(&rl.lock_manager_inner.servers[0], &key, &val).await);
 
         Ok(())
     }
@@ -454,10 +453,13 @@ mod tests {
         let key = rl.get_unique_lock_id()?;
 
         let val = rl.get_unique_lock_id()?;
-        let mut con = rl.servers[0].get_connection()?;
+        let mut con = rl.lock_manager_inner.servers[0].get_connection()?;
 
         redis::cmd("DEL").arg(&*key).execute(&mut con);
-        assert!(LockManager::lock_instance(&rl.servers[0], &*key, val.clone(), 1000).await);
+        assert!(
+            LockManager::lock_instance(&rl.lock_manager_inner.servers[0], &key, val.clone(), 1000)
+                .await
+        );
 
         Ok(())
     }
@@ -470,7 +472,7 @@ mod tests {
         let key = rl.get_unique_lock_id()?;
 
         let val = rl.get_unique_lock_id()?;
-        let mut con = rl.servers[0].get_connection()?;
+        let mut con = rl.lock_manager_inner.servers[0].get_connection()?;
         let _: () = redis::cmd("SET")
             .arg(&*key)
             .arg(&*val)
@@ -478,7 +480,7 @@ mod tests {
             .unwrap();
 
         let lock = Lock {
-            lock_manager: &rl,
+            lock_manager: rl.clone(),
             resource: key,
             val,
             validity_time: 0,


### PR DESCRIPTION
This resolve #13 
But I found that `Lock` can be cloned. If one thread clone it and send it to an other thread, one thread might think it still locked while it has been unlocked in the other thread. Should this be concerned? Maybe just remove the `Clone` derive?