### PR TITLE
Add from_clients for use directly from redis clients.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rslock"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   "Jan-Erik Rediger <badboy@archlinux.us>",
   "Romain Boces <bocesr@gmail.com>",

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
-use std::time::Duration;
 use rslock::LockManager;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
@@ -36,4 +36,3 @@ async fn main() {
     rl.unlock(&lock).await;
     println!("Lock released!");
 }
-

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1173,7 +1173,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_lock_manager_from_clients_valid_instance() {
-        let (_containers, addresses) = create_clients();
+        let (_containers, addresses) = create_clients().await;
 
         let clients: Vec<Client> = addresses
             .iter()
@@ -1188,7 +1188,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_lock_manager_from_clients_partial_quorum() {
-        let (_containers, addresses) = create_clients();
+        let (_containers, addresses) = create_clients().await;
         let mut clients: Vec<Client> = addresses
             .iter()
             .map(|uri| Client::open(uri.as_str()).unwrap())


### PR DESCRIPTION
Partly addresses #7, but this works with a client directly rather than a connection.