### PR TITLE
Enable TLS support for both async-std and tokio runtimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 edition = "2021"
 
 [features]
-async-std-comp = ["redis/async-std-comp"]
+async-std-comp = ["redis/async-std-rustls-comp"]
 tokio-comp = ["redis/tokio-rustls-comp"]
 default = ["async-std-comp"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 
 [features]
 async-std-comp = ["redis/async-std-comp"]
-tokio-comp = ["redis/tokio-comp"]
+tokio-comp = ["redis/tokio-rustls-comp"]
 default = ["async-std-comp"]
 
 [dependencies]


### PR DESCRIPTION
### What's in this PR?
This PR updates the feature configuration to enable TLS support via Rustls, allowing `rediss://` connections to work correctly with both Tokio and async-std runtimes.

Currently, attempts to use rediss:// result in a panic due to an unwrap() in the lock constructor: https://github.com/hexcowboy/rslock/blob/c875bf9b83072ecb66aa2f0358d90be3247b53f9/src/lock.rs#L125-L129

This panic comes from missing TLS feature support in the underlying [redis](https://github.com/redis-rs/redis-rs) crate, which checks TLS configuration here: https://github.com/redis-rs/redis-rs/blob/66253e42f6fc38773df986807f5ab81bc72808b0/redis/src/connection.rs#L386