### PR TITLE
chore: upgrade rand, tokio, redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ tokio-comp = ["redis/tokio-rustls-comp"]
 default = ["async-std-comp"]
 
 [dependencies]
-redis = { version = "0.27.5" }
-tokio = { version = "1.41.1", features = ["rt", "time"] }
-rand = "0.8.5"
+redis = { version = "0.29.5" }
+tokio = { version = "1.44.2", features = ["rt", "time"] }
+rand = "0.9.1"
 futures = "0.3.31"
 thiserror = "2.0.3"
 
@@ -34,5 +34,5 @@ thiserror = "2.0.3"
 once_cell = "^1.20.2"
 testcontainers = "^0.23.1"
 anyhow = "^1.0.93"
-tokio = { version = "^1.41.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "^1.44.2", features = ["macros", "rt-multi-thread"] }
 tokio-test = "^0.4.4"

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::future::join_all;
-use rand::{thread_rng, Rng, RngCore};
+use rand::{rng, Rng, RngCore};
 use redis::aio::MultiplexedConnection;
 use redis::Value::Okay;
 use redis::{Client, IntoConnectionInfo, RedisError, RedisResult, Value};
@@ -289,7 +289,7 @@ impl LockManager {
     /// Get 20 random bytes from the pseudorandom interface.
     pub fn get_unique_lock_id(&self) -> io::Result<Vec<u8>> {
         let mut buf = [0u8; 20];
-        thread_rng().fill_bytes(&mut buf);
+        rng().fill_bytes(&mut buf);
         Ok(buf.to_vec())
     }
 
@@ -367,7 +367,7 @@ impl LockManager {
                 .as_millis()
                 .try_into()
                 .map_err(|_| LockError::TtlTooLarge)?;
-            let n = thread_rng().gen_range(0..retry_delay);
+            let n = rng().random_range(0..retry_delay);
             tokio::time::sleep(Duration::from_millis(n)).await
         }
 


### PR DESCRIPTION
 - Update `tokio`, `rand`, and `redis` to latest in `Cargo.toml`
 - Update usage of `rand` following deprecation warnings
