### PR TITLE
feat: allow for arbitrary lock resource keys (via ToLockResource)

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,10 +15,7 @@ async fn main() {
 
     // Acquire a lock
     let lock = loop {
-        if let Ok(lock) = rl
-            .lock("mutex".as_bytes(), Duration::from_millis(1000))
-            .await
-        {
+        if let Ok(lock) = rl.lock("mutex", Duration::from_millis(1000)).await {
             break lock;
         }
     };

--- a/examples/from_clients.rs
+++ b/examples/from_clients.rs
@@ -21,10 +21,7 @@ async fn main() {
 
     // Acquire a lock
     let lock = loop {
-        if let Ok(lock) = rl
-            .lock("mutex".as_bytes(), Duration::from_millis(1000))
-            .await
-        {
+        if let Ok(lock) = rl.lock("mutex", Duration::from_millis(1000)).await {
             break lock;
         }
     };

--- a/examples/shared_lock.rs
+++ b/examples/shared_lock.rs
@@ -26,7 +26,7 @@ async fn main() {
             // Acquire the lock
             let lock = loop {
                 match lock_manager
-                    .lock("shared_mutex".as_bytes(), Duration::from_millis(2000))
+                    .lock("shared_mutex", Duration::from_millis(2000))
                     .await
                 {
                     Ok(lock) => break Arc::new(lock),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod resource;
+
 #[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
 mod lock;
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -8,6 +8,8 @@ use redis::aio::MultiplexedConnection;
 use redis::Value::Okay;
 use redis::{Client, IntoConnectionInfo, RedisError, RedisResult, Value};
 
+use crate::resource::{LockResource, ToLockResource};
+
 const DEFAULT_RETRY_COUNT: u32 = 3;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_millis(200);
 const CLOCK_DRIFT_FACTOR: f32 = 0.01;
@@ -137,7 +139,7 @@ impl RestorableConnection {
 }
 
 impl RestorableConnection {
-    async fn lock(&mut self, resource: &[u8], val: &[u8], ttl: usize) -> bool {
+    async fn lock(&mut self, resource: &LockResource<'_>, val: &[u8], ttl: usize) -> bool {
         let mut con = match self.get_connection().await {
             Err(_) => return false,
             Ok(val) => val,
@@ -163,7 +165,7 @@ impl RestorableConnection {
         }
     }
 
-    async fn extend(&mut self, resource: &[u8], val: &[u8], ttl: usize) -> bool {
+    async fn extend(&mut self, resource: &LockResource<'_>, val: &[u8], ttl: usize) -> bool {
         let mut con = match self.get_connection().await {
             Err(_) => return false,
             Ok(val) => val,
@@ -185,7 +187,8 @@ impl RestorableConnection {
         }
     }
 
-    async fn unlock(&mut self, resource: &[u8], val: &[u8]) -> bool {
+    async fn unlock(&mut self, resource: impl ToLockResource<'_>, val: &[u8]) -> bool {
+        let resource = resource.to_lock_resource();
         let mut con = match self.get_connection().await {
             Err(_) => return false,
             Ok(val) => val,
@@ -309,11 +312,13 @@ impl LockManager {
     // Can be used for creating or extending a lock
     async fn exec_or_retry(
         &self,
-        resource: &[u8],
+        resource: impl ToLockResource<'_>,
         value: &[u8],
         ttl: usize,
         function: Operation,
     ) -> Result<Lock, LockError> {
+        let resource = &resource.to_lock_resource();
+
         for _ in 0..self.retry_count {
             let start_time = Instant::now();
             let l = self.lock_inner().await;
@@ -358,7 +363,7 @@ impl LockManager {
             join_all(
                 servers
                     .iter_mut()
-                    .map(|client| client.unlock(resource, value)),
+                    .map(|client| client.unlock(&*resource, value)),
             )
             .await;
 
@@ -401,7 +406,7 @@ impl LockManager {
         join_all(
             servers
                 .iter_mut()
-                .map(|client| client.unlock(&lock.resource, &lock.val)),
+                .map(|client| client.unlock(&*lock.resource, &lock.val)),
         )
         .await;
     }
@@ -415,14 +420,19 @@ impl LockManager {
     /// A user should retry after a short wait time.
     ///
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
-    pub async fn lock(&self, resource: &[u8], ttl: Duration) -> Result<Lock, LockError> {
+    pub async fn lock(
+        &self,
+        resource: impl ToLockResource<'_>,
+        ttl: Duration,
+    ) -> Result<Lock, LockError> {
+        let resource = resource.to_lock_resource();
         let val = self.get_unique_lock_id().map_err(LockError::Io)?;
         let ttl = ttl
             .as_millis()
             .try_into()
             .map_err(|_| LockError::TtlTooLarge)?;
 
-        self.exec_or_retry(resource, &val.clone(), ttl, Operation::Lock)
+        self.exec_or_retry(&resource, &val.clone(), ttl, Operation::Lock)
             .await
     }
 
@@ -432,7 +442,11 @@ impl LockManager {
     ///
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
     #[cfg(feature = "async-std-comp")]
-    pub async fn acquire(&self, resource: &[u8], ttl: Duration) -> Result<LockGuard, LockError> {
+    pub async fn acquire(
+        &self,
+        resource: impl ToLockResource<'_>,
+        ttl: Duration,
+    ) -> Result<LockGuard, LockError> {
         let lock = self.acquire_no_guard(resource, ttl).await?;
         Ok(LockGuard { lock })
     }
@@ -445,9 +459,10 @@ impl LockManager {
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
     pub async fn acquire_no_guard(
         &self,
-        resource: &[u8],
+        resource: impl ToLockResource<'_>,
         ttl: Duration,
     ) -> Result<Lock, LockError> {
+        let resource = &resource.to_lock_resource();
         loop {
             match self.lock(resource, ttl).await {
                 Ok(lock) => return Ok(lock),
@@ -464,7 +479,7 @@ impl LockManager {
             .try_into()
             .map_err(|_| LockError::TtlTooLarge)?;
 
-        self.exec_or_retry(&lock.resource, &lock.val, ttl, Operation::Extend)
+        self.exec_or_retry(&*lock.resource, &lock.val, ttl, Operation::Extend)
             .await
     }
 
@@ -664,13 +679,14 @@ mod tests {
 
         let rl = LockManager::new(addresses.clone());
         let key = rl.get_unique_lock_id()?;
+        let resource = key.to_lock_resource();
 
         let val = rl.get_unique_lock_id()?;
         let mut l = rl.lock_inner().await;
         let mut con = l.servers[0].get_connection().await?;
 
         redis::cmd("DEL").arg(&*key).exec_async(&mut con).await?;
-        assert!(l.servers[0].lock(&key, &val, 10_000).await);
+        assert!(l.servers[0].lock(&resource, &val, 10_000).await);
         Ok(())
     }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,81 @@
+use redis::{RedisWrite, ToRedisArgs};
+use std::borrow::Cow;
+
+pub struct LockResource<'a> {
+    bytes: Cow<'a, [u8]>,
+}
+
+impl<'a> LockResource<'a> {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.bytes.to_vec()
+    }
+}
+
+pub trait ToLockResource<'a> {
+    fn to_lock_resource(self) -> LockResource<'a>;
+}
+
+impl<'a> ToLockResource<'a> for &'a LockResource<'a> {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Borrowed(&*self.bytes),
+        }
+    }
+}
+
+impl<'a> ToLockResource<'a> for &'a [u8] {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Borrowed(self),
+        }
+    }
+}
+
+impl<'a, const N: usize> ToLockResource<'a> for &'a [u8; N] {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Borrowed(self),
+        }
+    }
+}
+
+impl<'a> ToLockResource<'a> for &'a Vec<u8> {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Borrowed(self),
+        }
+    }
+}
+
+impl<'a> ToLockResource<'a> for &'a str {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Borrowed(self.as_bytes()),
+        }
+    }
+}
+
+impl<'a> ToLockResource<'a> for &'a [&'a str] {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Owned(self.join("").as_bytes().to_vec()),
+        }
+    }
+}
+
+impl<'a> ToLockResource<'a> for &'a [&'a [u8]] {
+    fn to_lock_resource(self) -> LockResource<'a> {
+        LockResource {
+            bytes: Cow::Owned(self.concat()),
+        }
+    }
+}
+
+impl<'a> ToRedisArgs for LockResource<'a> {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.bytes.write_redis_args(out)
+    }
+}


### PR DESCRIPTION
Allows for `.lock` and friends on `LockManager` to take various arguments

- Backwards compatible (examples compiled before I changed to show)
- Allows for strings, bytes, and arrays of both (could be extended further)

```rs
// use a resource name directly (no .as_bytes)
rl.acquire("resource", ttl).await?;

// allow for arrays to make it easier for resource namespacing
rl.acquire(&["user", &user_id], ttl).await?;
```