### PR TITLE
chore: expose query_redis_for_key_value

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -392,7 +392,7 @@ impl LockManager {
     }
 
     // Query Redis for a key's value and keep trying each server until a successful result is returned
-    async fn query_redis_for_key_value(
+    pub async fn query_redis_for_key_value(
         &self,
         resource: &[u8],
     ) -> Result<Option<Vec<u8>>, LockError> {


### PR DESCRIPTION
Currently, `LockManager` abstracts away the underlying Redis connections, which prevents users from inspecting the value of a lock they failed to acquire without creating a separate, redundant Redis client.

In distributed systems where a lock represents "Leader" or "Worker" ownership of a resource, the lock's **value** often contains the address (e.g., DNS name or IP) of the current owner.

If a client fails to acquire a lock (`lock()` returns `Err`), they often need to "follow" the lock by reading its value to find out who currently owns it (e.g., to proxy a request to the active leader).

This allows users to reuse the existing connection pool managed by `rslock` to perform these lookups, rather than managing a secondary Redis pool just for inspection.

```rust
// Example usage enabled by this PR:
let manager = LockManager::new(uris);

match manager.lock(resource, ttl).await {
    Ok(lock) => { /* I am the leader */ },
    Err(_) => {
        // I am not the leader, but I can now find out who is:
        if let Ok(Some(value)) = manager.query_redis_for_key_value(resource).await {
             let leader_address = String::from_utf8(value).unwrap();
             // proxy_request(leader_address, ...);
        }
    }
}
```