### PR TITLE
version 0.7.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ tokio-comp = ["redis/tokio-rustls-comp"]
 default = ["async-std-comp"]
 
 [dependencies]
-redis = { version = "0.32.2" }
-tokio = { version = "1.45.1", features = ["rt", "time"] }
-rand = "0.9.1"
+redis = { version = "0.32.7" }
+tokio = { version = "1.49.0", features = ["rt", "time"] }
+rand = "0.9.2"
 futures = "0.3.31"
-thiserror = "2.0.12"
+thiserror = "2.0.18"
 
 [dev-dependencies]
-once_cell = "^1.20.2"
-testcontainers = "^0.23.1"
-anyhow = "^1.0.93"
-tokio = { version = "^1.41.1", features = ["macros", "rt-multi-thread"] }
-tokio-test = "^0.4.4"
+once_cell = "^1.21.3"
+testcontainers = "^0.23.3"
+anyhow = "^1.0.101"
+tokio = { version = "^1.49.0", features = ["macros", "rt-multi-thread"] }
+tokio-test = "^0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rslock"
-version = "0.7.3"
+version = "0.7.4"
 authors = [
   "Jan-Erik Rediger <badboy@archlinux.us>",
   "Romain Boces <bocesr@gmail.com>",

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -392,7 +392,7 @@ impl LockManager {
     }
 
     // Query Redis for a key's value and keep trying each server until a successful result is returned
-    async fn query_redis_for_key_value(
+    pub async fn query_redis_for_key_value(
         &self,
         resource: &[u8],
     ) -> Result<Option<Vec<u8>>, LockError> {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -366,7 +366,7 @@ impl LockManager {
             join_all(
                 servers
                     .iter_mut()
-                    .map(|client| client.unlock(&*resource, value)),
+                    .map(|client| client.unlock(resource, value)),
             )
             .await;
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -5,7 +5,7 @@ pub struct LockResource<'a> {
     bytes: Cow<'a, [u8]>,
 }
 
-impl<'a> LockResource<'a> {
+impl LockResource<'_> {
     pub fn to_vec(&self) -> Vec<u8> {
         self.bytes.to_vec()
     }
@@ -71,7 +71,7 @@ impl<'a> ToLockResource<'a> for &'a [&'a [u8]] {
     }
 }
 
-impl<'a> ToRedisArgs for LockResource<'a> {
+impl ToRedisArgs for LockResource<'_> {
     fn write_redis_args<W>(&self, out: &mut W)
     where
         W: ?Sized + RedisWrite,


### PR DESCRIPTION
## Summary
- bump direct dependencies in `Cargo.toml` to newer compatible releases
- keep `redis` and `testcontainers` on compatible major versions to preserve existing feature/API usage
- run `cargo clippy --all-targets --all-features` to validate the update set on the current toolchain