### PR TITLE
update dependencies and bump version to 0.8.0 (#49)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rslock"
-version = "0.7.4"
+version = "0.8.0"
 authors = [
   "Jan-Erik Rediger <badboy@archlinux.us>",
   "Romain Boces <bocesr@gmail.com>",
@@ -19,15 +19,16 @@ readme = "README.md"
 edition = "2021"
 
 [features]
-async-std-comp = ["redis/async-std-rustls-comp"]
+# redis 1.x dropped async-std features; smol-rustls-comp is the non-Tokio async stack.
+smol-rustls-comp = ["redis/smol-rustls-comp"]
 tokio-comp = ["redis/tokio-rustls-comp"]
-default = ["async-std-comp"]
+default = ["smol-rustls-comp"]
 
 [dependencies]
-redis = { version = "0.32.7" }
-tokio = { version = "1.49.0", features = ["rt", "time"] }
-rand = "0.9.2"
-futures = "0.3.31"
+redis = { version = "1.2.0" }
+tokio = { version = "1.52.1", features = ["rt", "time"] }
+rand = "0.10.1"
+futures = "0.3.32"
 thiserror = "2.0.18"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is an implementation of Redlock, the [distributed locking mechanism](http:/
 ## Features
 
 - Lock extending
-- Async runtime support (async-std and tokio)
+- Async runtime support (smol-rustls-comp and tokio)
 - Async redis
 
 ## Install
@@ -22,7 +22,7 @@ cargo add rslock --vers "~0.7.2"
 ```
 
 > [!NOTE]
-> The `default` feature of this crate will provide `async-std`. You may optionally use tokio by supplying the `tokio-comp` feature flag when installing.
+> The `default` feature of this crate will provide `smol-rustls-comp`. You may optionally use tokio by supplying the `tokio-comp` feature flag when installing.
 
 ## Build
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod resource;
 
-#[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
+#[cfg(any(feature = "smol-rustls-comp", feature = "tokio-comp"))]
 mod lock;
 
-#[cfg(any(feature = "async-std-comp", feature = "tokio-comp"))]
+#[cfg(any(feature = "smol-rustls-comp", feature = "tokio-comp"))]
 pub use crate::lock::{Lock, LockError, LockGuard, LockManager};

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::future::join_all;
-use rand::{rng, Rng, RngCore};
+use rand::{rng, Rng, RngExt};
 use redis::aio::MultiplexedConnection;
 use redis::Value::Okay;
 use redis::{Client, IntoConnectionInfo, RedisError, RedisResult, Value};
@@ -453,7 +453,7 @@ impl LockManager {
     /// The lock is placed in a guard that will unlock the lock when the guard is dropped.
     ///
     /// May return `LockError::TtlTooLarge` if `ttl` is too large.
-    #[cfg(feature = "async-std-comp")]
+    #[cfg(feature = "smol-rustls-comp")]
     pub async fn acquire(
         &self,
         resource: impl ToLockResource<'_>,
@@ -813,7 +813,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+    #[cfg(all(not(feature = "tokio-comp"), feature = "smol-rustls-comp"))]
     #[tokio::test]
     async fn test_lock_lock_unlock_raii() -> Result<()> {
         let (_containers, addresses) = create_clients().await;
@@ -858,7 +858,7 @@ mod tests {
         let key = rl1.get_unique_lock_id()?;
 
         async {
-            //The acquire function is only enabled for `async-std-comp` ??
+            //The acquire function is only enabled for `smol-rustls-comp` ??
             let lock_guard = rl1
                 .acquire(&key, Duration::from_millis(10_000))
                 .await
@@ -910,7 +910,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "async-std-comp")]
+    #[cfg(feature = "smol-rustls-comp")]
     #[tokio::test]
     async fn test_lock_extend_lock() -> Result<()> {
         let (_containers, addresses) = create_clients().await;
@@ -950,7 +950,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "async-std-comp")]
+    #[cfg(feature = "smol-rustls-comp")]
     #[tokio::test]
     async fn test_lock_extend_lock_releases() -> Result<()> {
         let (_containers, addresses) = create_clients().await;


### PR DESCRIPTION
Hello,

This updates Redis (and some other dependencies) as requested in #49.
I also bumped the version.. I can revert that if that's too much.
I ran the available tests and they looked fine but I needed to change the runtime (async to smol).